### PR TITLE
Update Terms of Use link to newer license URL

### DIFF
--- a/src/app/python-packages/home/terms-modal/terms-modal.component.ts
+++ b/src/app/python-packages/home/terms-modal/terms-modal.component.ts
@@ -9,7 +9,7 @@ import { MessageService } from '../../services/message.service';
 })
 export class TermsModalComponent extends BaseModal implements  OnInit {
 
-  openLicenseTerms: string = "https://www.ibm.com/support/customer/csol/terms/?id=L-SYAG-CJGMZ2&lc=en#detail-document";
+  openLicenseTerms: string = "https://www.ibm.com/support/customer/csol/terms/?id=L-MZYZ-TUDP2Q&lc=en";
   size: string = "md";
   theme: string = "light";
   @Input() hasScrollingContent: boolean = true;

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -63,7 +63,7 @@
         "TERMS_OF_USE": "Terms of use",
         "AGREE_MODAL_TITLE": "Python® AI Toolkit for IBM® z/OS® Agreement",
         "AGREE_MODAL_CONTENT1": "Please review the terms of use for Python® AI Toolkit for IBM® z/OS® by clicking the link below:",
-        "AGREE_MODAL_CONTENT2": "https://www.ibm.com/support/customer/csol/terms/?id=L-SYAG-CJGMZ2&lc=en#detail-document",
+        "AGREE_MODAL_CONTENT2": "https://www.ibm.com/support/customer/csol/terms/?id=L-MZYZ-TUDP2Q&lc=en",
         "AGREE_MODAL_CONTENT3": "By clicking Agree and proceeding to this site, you are agreeing to these licensing terms.",
         "AGREE": "Agree",
         "PACKAGES": "Packages",

--- a/src/assets/i18n/ja.json
+++ b/src/assets/i18n/ja.json
@@ -63,7 +63,7 @@
         "TERMS_OF_USE": "Terms of use",
         "AGREE_MODAL_TITLE": "Python® AI Toolkit for IBM® z/OS® Agreement",
         "AGREE_MODAL_CONTENT1": "Please review the terms of use for Python® AI Toolkit for IBM® z/OS® by clicking the link below:",
-        "AGREE_MODAL_CONTENT2": "https://www.ibm.com/support/customer/csol/terms/?id=L-SYAG-CJGMZ2&lc=en#detail-document",
+        "AGREE_MODAL_CONTENT2": "https://www.ibm.com/support/customer/csol/terms/?id=L-MZYZ-TUDP2Q&lc=en",
         "AGREE_MODAL_CONTENT3": "By clicking Agree and proceeding to this site, you are agreeing to these licensing terms.",
         "AGREE": "Agree",
         "PACKAGES": "Packages",

--- a/src/assets/packageInfo.json
+++ b/src/assets/packageInfo.json
@@ -52,11 +52,11 @@
     "usage_notes": "<p>For advanced tool documentation, refer to <a href=\"https://babel.pocoo.org/en/latest/api/core.html#basic-interface\">babel.pocoo.org</a>.</p>",
     "tags": "languages",
     "versions": {
-      "2.16.0": {
+      "2.17.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "4cc7103c241fa2d2d14871911aebd6085b74dd1534e3f73744f7f9a7adadcffb"
+            "sha256": "6f2f2682e67c68b49b3f45f5a42b231308d207af68fe5caded8137038d399f7e"
           }
         ]
       }
@@ -157,11 +157,11 @@
     "usage_notes": "\n<p>A core requirement of dealing with packages is the ability to work with versions. <a href=\"https://www.python.org/dev/peps/pep-0440/\">PEP 440</a> defines the standard version scheme for Python packages which has been implemented by this module.</p>\n\n<pre><code>\nfrom packaging.version import Version, parse<br>\nv1 = parse(\"1.0a5\")<br>\nv2 = Version(\"1.0\")<br>\nv1<br>\n   &lt;Version('1.0a5')&gt;<br>\nv2<br>\n   &lt;Version('1.0')&gt;<br>\nv1 &lt; v2<br>\n   True<br>\nv1.epoch<br>\n   0<br>\nv1.release<br>\n   (1, 0)<br>\nv1.pre<br>\n   ('a', 5)<br>\nv1.is_prerelease<br>\n   True<br>\nv2.is_prerelease<br>\n   False<br>\nVersion(\"french toast\")<br>\n   Traceback (most recent call last):<br>\n       ...<br>\n   InvalidVersion: Invalid version: 'french toast'<br>\nVersion(\"1.0\").post<br>\nVersion(\"1.0\").is_postrelease<br>\n   False<br>\nVersion(\"1.0.post0\").post<br>\n   0<br>\nVersion(\"1.0.post0\").is_postrelease<br>\n   True<br>\n</code></pre>\n\n<p>Please refer to <a href=\"https://packaging.pypa.io/en/latest/version.html\">packaging.pypa.io</a> for further documentation.</p>",
     "tags": "programming_tools",
     "versions": {
-      "23.0": {
+      "25.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2"
+            "sha256": "dd07f76949ec3a2adc24e913524852e6993c0f88fe4c49f6dde59317158dd4e5"
           }
         ]
       }
@@ -199,19 +199,19 @@
     "usage_notes": "<p>Example of usage:</p>\n<pre><code>\n&gt;&gt;&gt; from markupsafe import Markup, escape<br>\n<br>\n&gt;&gt;&gt; # escape replaces special characters and wraps in Markup<br>\n&gt;&gt;&gt; escape(\"&lt;script&gt;alert(document.cookie);&lt;/script&gt;\")<br>\nMarkup('&amp;lt;script&amp;gt;alert(document.cookie);&amp;lt;/script&amp;gt;')<br>\n<br>\n&gt;&gt;&gt; # wrap in Markup to mark text \"safe\" and prevent escaping<br>\n&gt;&gt;&gt; Markup(\"&lt;strong&gt;Hello&lt;/strong&gt;\")<br>\nMarkup('&lt;strong&gt;hello&lt;/strong&gt;')<br>\n<br>\n&gt;&gt;&gt; escape(Markup(\"&lt;strong&gt;Hello&lt;/strong&gt;\"))<br>\nMarkup('&lt;strong&gt;hello&lt;/strong&gt;')<br>\n<br>\n&gt;&gt;&gt; # Markup is a str subclass<br>\n&gt;&gt;&gt; # methods and operators escape their arguments<br>\n&gt;&gt;&gt; template = Markup(\"Hello &lt;em&gt;{name}&lt;/em&gt;\")<br>\n&gt;&gt;&gt; template.format(name='\"World\"')<br>\nMarkup('Hello &lt;em&gt;&amp;#34;World&amp;#34;&lt;/em&gt;')<br>\n</code></pre>\n\n<p>See <a href=\"https://markupsafe.palletsprojects.com/en/2.1.x/\">markupsafe.pallasprojects.com</a> for additional documentation.</p>",
     "tags": "security utility",
     "versions": {
-      "3.0.1": {
+      "3.0.2": {
         "dist": [
           {
             "py_version": "cp311",
-            "sha256": "ba397724bfd8e44740eb3fe685c833adf0ef636ad0a223d55e565faf2560bd49"
+            "sha256": "967b101fb8b25a523aa029dbfc5906036190729732f11ce22c0340ee00b0d63b"
           },
           {
             "py_version": "cp312",
-            "sha256": "911de621b4ad0444763b1dab24be269813d151b8b54202dc7e908febdf59f3d4"
+            "sha256": "0079e0c0affb39cd717479d42442615574c36ae64c5ea74d84dbc6d91075f53a"
           },
           {
             "py_version": "cp313",
-            "sha256": "886267583e2be24adbec69a2c8ed1429f459f7be42db6400f54b578927c033da"
+            "sha256": "afc7c549592a4eb71e390a9b2c079b1540a7594aa10d596232df685663538a6b"
           }
         ]
       }
@@ -229,11 +229,11 @@
     " python -m certifi<br>": "/usr/local/lib/python3.7/site-packages/certifi/cacert.pem<br>\n</code></pre>\n<p>Additional documentation is available via <a href=\"https://certifiio.readthedocs.io/en/latest/\">readthedocs.io</a></p>",
     "tags": "security",
     "versions": {
-      "2024.2.2": {
+      "2025.8.3": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "9332e0c336a2c52fcc7b7ad2984dea39c21c756f98b1a53c3560cd1606dbfb70"
+            "sha256": "71f200f55e7d81b9d330fe9c0e28f9d8cdb4548ba3e0904e801e248986bfd8e7"
           }
         ]
       }
@@ -397,11 +397,11 @@
     "usage_notes": "<p>Usage information is available on <a href=\"https://github.com/andialbrecht/sqlparse\">github.com</a>.</p>",
     "tags": "utility database",
     "versions": {
-      "0.5.0": {
+      "0.5.3": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "363b68a6444c60ba545c142bf552e4bd247db65f3ae68999ce2213ea0e20b369"
+            "sha256": "396ca8435357a7ab813637c816a73e5e9fb5c20c7f1df5ff69426a755d18235c"
           }
         ]
       }
@@ -649,11 +649,11 @@
     "usage_notes": "<p>More information is available on <a href=\"https://websocket-client.readthedocs.io/en/latest/\">readthedocs.io</a>.</p>",
     "tags": "utility web",
     "versions": {
-      "1.7.0": {
+      "1.8.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "1cf1c0d54a1b5b344b341b0a8a4ae174baf699da573f0c173962b5f3f065152d"
+            "sha256": "a2ca2931281b92f7ecdc3060c9bb17f484e71097c292e923b00832944b727818"
           }
         ]
       }
@@ -791,11 +791,11 @@
     "usage_notes": "<p>Here's an exampe of usage:</p>\n\n<p>In this example we create an LRU dictionary backed by pickle-encoded, zlib-compressed, directory of files.</p>\n<pre>\n<code>\nimport pickle<br>\nimport zlib<br>\n<br>\nfrom zict import File, Func, LRU<br>\n<br>\na = File('myfile/', mode='a')<br>\nb = Func(zlib.compress, zlib.decompress, a)<br>\nc = Func(pickle.dumps, pickle.loads, b)<br>\nd = LRU(100, c)<br>\n<br>\n>>> d['x'] = [1, 2, 3]<br>\n>>> d['x']<br>\n[1, 2, 3]<br>\n</code></pre>\n\n<p>Further examples and all documentation is available on <a href=\"https://zict.readthedocs.io/en/latest/\">readthedocs.io</a></p>",
     "tags": "programming_tools",
     "versions": {
-      "2.2.0": {
+      "3.0.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "3f2551d3077804de839d4e131142a56e116c6a1341b0197bbccdd6b0f1c57ecc"
+            "sha256": "56932fc708718225a29cc79487c4bd995a93e95add7af0ad341377b58de5d5a8"
           }
         ]
       }
@@ -896,11 +896,19 @@
     "usage_notes": "<p>The function <code>yaml.load</code> converts a YAML document to a Python object.</p>\n\n<pre><code>\n&gt;&gt;&gt; yaml.load(\"\"\"<br>\n... - Hesperiidae<br>\n... - Papilionidae<br>\n... - Apatelodidae<br>\n... - Epiplemidae<br>\n... \"\"\")<br>\n<br>\n...<br>\n<br>\n['Hesperiidae', 'Papilionidae', 'Apatelodidae', 'Epiplemidae']<br>\n</code></pre>\n\n<p>The counterpart <code>yaml.dump</code> function accepts a Python object and produces a YAML document.</p>\n\n<p>Complete documentation can be found on <a href=\"https://pyyaml.org/wiki/PyYAMLDocumentation\">pyyaml.org</a>.</p>",
     "tags": "programming_tools utility languages",
     "versions": {
-      "6.0.1.post0": {
+      "6.0.2": {
         "dist": [
           {
+            "py_version": "cp311",
+            "sha256": "693b9f16e1d1e2c846ad3001355267e7433bd83d244ac454f88081a35eb58841"
+          },
+          {
+            "py_version": "cp312",
+            "sha256": "7e6b41c1f31e8b2fe367fdbbf7ae9cb3cee4ff3c96ab7b3d825d9d36d97aac7a"
+          },
+          {
             "py_version": "cp313",
-            "sha256": "efff9fa9120a2654d9e8937dcfce92cb8e7c3b6977fe8527b314c10b6f7f2e23"
+            "sha256": "d5ff4e02057ac0c1299657e7425333f76129ee8468e19fd4c5212acda8335d6b"
           }
         ]
       }
@@ -1190,11 +1198,11 @@
     "usage_notes": "<p>Here is a small example for highlighting Python code:</p>\n\n<pre><code>\nfrom pygments import highlight<br>\nfrom pygments.lexers import PythonLexer<br>\nfrom pygments.formatters import HtmlFormatter<br>\n<br>\ncode = 'print \"Hello World\"'<br>\nprint(highlight(code, PythonLexer(), HtmlFormatter()))<br>\n</code></pre>\n\n<p>Documentation is available on <a href=\"https://pygments.org/docs/\">pygments.org</a>.</p>",
     "tags": "languages",
     "versions": {
-      "2.16.1": {
+      "2.19.2": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "1e6fdcb477daec1e6f52eaef3181369dfde6cdc4939087cfcf5cb003e4dc3baa"
+            "sha256": "b6d1466a36dfdad61a239e39d0180829c6485dd6a7e81c53c3c163bf94e1aca8"
           }
         ]
       }
@@ -1295,14 +1303,6 @@
     "usage_notes": "<p>NumPy\u2019s main object is the homogeneous multidimensional array. It is a table of elements (usually numbers), all of the same type, indexed by a tuple of non-negative integers. In NumPy dimensions are called axes.</p>\n\n<p>\nFor example, the array for the coordinates of a point in 3D space, [1, 2, 1], has one axis. That axis has 3 elements in it, so we say it has a length of 3. In the example pictured below, the array has 2 axes. The first axis has a length of 2, the second axis has a length of 3.</p>\n\n<pre><code>\n[[1., 0., 0.],<br>\n [0., 1., 2.]]<br>\n</code></pre>\n\n<p>NumPy\u2019s array class is called <code>ndarray</code>. It is also known by the alias <code>array</code>. Note that <code>numpy.array</code> is not the same as the Standard Python Library class <code>array.array</code>, which only handles one-dimensional arrays and offers less functionality.</p>\n\n<p>Please refer to <a href=\"https://numpy.org/doc/1.22/user/quickstart.html\">numpy.org</a> for a quickstart guide.</p>",
     "tags": "math",
     "versions": {
-      "1.26.0": {
-        "dist": [
-          {
-            "py_version": "cp312",
-            "sha256": "c549358bea31eba0809cea3b0675fc5817f995966d6d23543919cda922db863d"
-          }
-        ]
-      },
       "2.0.2": {
         "dist": [
           {
@@ -1445,11 +1445,11 @@
     "usage_notes": "\n<h4>Example of usage:</h4>\n<pre><code>\n>>> from argon2 import PasswordHasher<br>\n>>> ph = PasswordHasher()<br>\n>>> hash = ph.hash(\"correct horse battery staple\")<br>\n>>> hash  # doctest: +SKIP<br>\n'$argon2id$v=19$m=65536,t=3,p=4$MIIRqgvgQbgj220jfp0MPA$YfwJSVjtjSU0zzV/P3S9nnQ/USre2wvJMjfCIjrTQbg'<br>\n>>> ph.verify(hash, \"correct horse battery staple\")<br>\nTrue<br>\n>>> ph.check_needs_rehash(hash)<br>\nFalse<br>\n>>> ph.verify(hash, \"Tr0ub4dor&3\")<br>\nTraceback (most recent call last):<br>\n  ...<br>\nargon2.exceptions.VerifyMismatchError: The password does not match the supplied hash<br>\n</code></pre>\n<p>Further documentation is available via the <a href=\"https://argon2-cffi.readthedocs.io/en/stable/#user-s-guide\">User's Guide</a></p>",
     "tags": "security",
     "versions": {
-      "21.3.0": {
+      "25.1.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "ca8776f6acbb0d565b739f1276dea6b6642c3d82d07d5e3456f3a806795eb3ac"
+            "sha256": "5cbc18736317dc007b7954bf49cf09b5512d97f888df01a896fd91f3d9c7b953"
           }
         ]
       }
@@ -1592,11 +1592,11 @@
     "usage_notes": "<p>More information is available on <a href=\"https://webcolors.readthedocs.io/en/latest/\">readthedocs.io</a>.</p>",
     "tags": "utility web",
     "versions": {
-      "1.13": {
+      "24.11.1": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "48d15a0aeedc55d66c3addb43de2ef7356bb7ed030945c6e7f4d641bc5c1ca7b"
+            "sha256": "3bae18f006df0adac73d50e20faa74304de6d38802ee800678c6c0b5c808ba6f"
           }
         ]
       }
@@ -2021,11 +2021,11 @@
     "usage_notes": "\n<h4>Example of usage:</h4>\n<pre><code>\n>>> from attrs import asdict, define, make_class, Factory<br>\n<br>\n>>> @define<br>\n... class SomeClass:<br>\n...     a_number: int = 42<br>\n...     list_of_numbers: list[int] = Factory(list)<br>\n...<br>\n...     def hard_math(self, another_number):<br>\n...         return self.a_number + sum(self.list_of_numbers) * another_number<br>\n<br>\n<br>\n>>> sc = SomeClass(1, [1, 2, 3])<br>\n>>> sc<br>\nSomeClass(a_number=1, list_of_numbers=[1, 2, 3])<br>\n<br>\n>>> sc.hard_math(3)<br>\n19<br>\n>>> sc == SomeClass(1, [1, 2, 3])<br>\nTrue<br>\n>>> sc != SomeClass(2, [3, 2, 1])<br>\nTrue<br>\n<br>\n>>> asdict(sc)<br>\n{'a_number': 1, 'list_of_numbers': [1, 2, 3]}<br>\n<br>\n>>> SomeClass()<br>\nSomeClass(a_number=42, list_of_numbers=[])<br>\n<br>\n>>> C = make_class(\"C\", [\"a\", \"b\"])<br>\n>>> C(\"foo\", \"bar\")<br>\nC(a='foo', b='bar')<br>\n</code></pre>\n<p>Further documentation is available on the <a href=\"https://www.attrs.org/en/stable/#getting-started\">getting started</a> guide.</p>",
     "tags": "programming_tools",
     "versions": {
-      "22.2.0": {
+      "25.3.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "29e95c7f6778868dbd49170f98f8818f78f3dc5e0e37c0b1f474e3561b240836"
+            "sha256": "c7bc1248a08b51bb1cd792ec1495880e26797db33e04368bf173aaf18af79d84"
           }
         ]
       }
@@ -2084,11 +2084,11 @@
     "usage_notes": "<p>Any class with trait attributes must inherit from <code>HasTraits</code>. For the list of available trait types and their properties, see the <a href=\"https://traitlets.readthedocs.io/en/latest/trait_types.html\">Trait Types</a> section of the documentation.</p>\n<h4>Dynamic default values</h4>\n<p>To calculate a default value dynamically, decorate a method of your class with <code>@default({traitname})</code>. This method will be called on the instance, and should return the default value. In this example, the <code>_username_default</code> method is decorated with <code>@default('username')</code>:</p>\n<pre><code>\nimport getpass<br>\nfrom traitlets import HasTraits, Unicode, default<br>\n<br>\nclass Identity(HasTraits):<br>\n    username = Unicode()<br>\n<br>\n    @default('username')<br>\n    def _username_default(self):<br>\n        return getpass.getuser()<br>\n</pre></code>\n\n<h4>Callbacks when a trait attribute changes</h4>\n<p>When a trait changes, an application can follow this trait change with additional actions.</p>\n<p>To do something when a trait attribute is changed, decorate a method with <code>traitlets.observe()</code>. The method will be called with a single argument, a dictionary which contains an owner, new value, old value, name of the changed trait, and the event type.</p>\n<p>In this example, the <code>_num_changed</code> method is decorated with <code>@observe(`num`)</code>:</p>\n\n<pre><code>\nfrom traitlets import HasTraits, Integer, observe<br>\n<br>\nclass TraitletsExample(HasTraits):<br>\n    num = Integer(5, help=\"a number\").tag(config=True)<br>\n<br>\n    @observe('num')<br>\n    def _num_changed(self, change):<br>\n        print(\"{name} changed from {old} to {new}\".format(**change))<br>\n</code></pre>\n<p>and is passed the following dictionary when called:</p>\n\n<pre><code>\n{<br>\n  'owner': object,  # The HasTraits instance<br>\n  'new': 6,         # The new value<br>\n  'old': 5,         # The old value<br>\n  'name': \"foo\",    # The name of the changed trait<br>\n  'type': 'change', # The event type of the notification, usually 'change'<br>\n}<br>\n</code></pre>\n\n<h4>Validation and coercion</h4>\n<p>Each trait type (<code>Int</code>, <code>Unicode</code>, <code>Dict</code> etc.) may have its own validation or coercion logic. In addition, we can register custom cross-validators that may depend on the state of other attributes. For example:</p>\n\n<pre><code>\nfrom traitlets import HasTraits, TraitError, Int, Bool, validate<br>\n<br>\nclass Parity(HasTraits):<br>\n    value = Int()<br>\n    parity = Int()<br>\n<br>\n    @validate('value')<br>\n    def _valid_value(self, proposal):<br>\n        if proposal['value'] % 2 != self.parity:<br>\n            raise TraitError('value and parity should be consistent')<br>\n        return proposal['value']<br>\n<br>\n    @validate('parity')<br>\n    def _valid_parity(self, proposal):<br>\n        parity = proposal['value']<br>\n        if parity not in [0, 1]:<br>\n            raise TraitError('parity should be 0 or 1')<br>\n        if self.value % 2 != parity:<br>\n            raise TraitError('value and parity should be consistent')<br>\n        return proposal['value']<br>\n<br>\nparity_check = Parity(value=2)<br>\n<br>\n# Changing required parity and value together while holding cross validation<br>\nwith parity_check.hold_trait_notifications():<br>\n    parity_check.value = 1<br>\n    parity_check.parity = 1<br>\n</code></pre>\n<p>However, we <b>recommend</b> that custom cross-validators don't modify the state of the HasTraits instance.</p>\n\n<p>Further documentation is available on <a href=\"https://traitlets.readthedocs.io/en/stable/\">readthedocs.io</a></p>",
     "tags": "programming_tools",
     "versions": {
-      "5.9.0": {
+      "5.14.3": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "9e6ec080259b9a5940c797d58b613b5e31441c2257b87c2e795c5228ae80d2d8"
+            "sha256": "39a220b5126b3520d07370caedca7a2ca6d40ab95ed5ec524d889f17a77c994d"
           }
         ]
       }
@@ -2239,11 +2239,11 @@
     "usage_notes": "<p>For python package configurable-http-proxy, the following options are not supported (yet), since they are still not supported from the Open Source Community.</p>\n<ul>\n <li>SSL for proxy, client, API is not available (--ssl-*, --api-ssl-*, --client-ssl-*, --insecure)</li>\n <li>Redirecting: --redirect-port and --redirect-to</li>\n <li>Change Origin: --change-origin</li>\n <li>Rewrites in Location header: --protocol-rewrite and --auto-rewrite</li>\n <li>Metrics server: --metrics-port and --metrics-ip</li>\n</ul>\n<p>If the above options/features are needed, you will need to install the Node.js module \u201cconfigurable-http-proxy\u201d, such as, \u201cnpm install -g configurable-http-proxy\u201d to install the configurable-http-proxy package globally using npm.</p>\n\n<p>More information is available on <a href=\"https://github.com/corridor/configurable-http-proxy\">github.com</a>.</p>",
     "tags": "web",
     "versions": {
-      "0.3.0": {
+      "0.4.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "20ed6106f25f76c94693b81cd8a04981e1d963bdac751f8c69d9c600ccba6cdc"
+            "sha256": "dd423614bae75621bc299e510996951e9091ef2ec3956fc7a4958cbaab0f0bdb"
           }
         ]
       }
@@ -2281,11 +2281,11 @@
     "usage_notes": "<p>Usage information is available on <a href=\"https://github.com/sqlalchemy/alembic\">github.com</a>.</p>",
     "tags": "utility",
     "versions": {
-      "1.15.2": {
+      "1.16.5": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "487c2acea1c39d9369c44367f9fbc87fe6d582abeb9ce1ebb76b36a4db1ee295"
+            "sha256": "79fd3fd5f5cda58f079ccebb45ce994a43b13c36adc306962408a2b1d6e3a921"
           }
         ]
       }
@@ -2604,11 +2604,11 @@
     "usage_notes": "<pre><code>\n&gt;&gt;&gt; from send2trash import send2trash<br>\n&gt;&gt;&gt; send2trash('some_file')<br>\n&gt;&gt;&gt; send2trash(['some_file1', 'some_file2'])<br>\n</code></pre>\n\n<p>On Freedesktop platforms (Linux, BSD, etc.), you may not be able to efficiently trash some files. In these cases, an exception <code>send2trash.TrashPermissionError</code> is raised, so that the application can handle this case. This inherits from <code>PermissionError</code> (<code>OSError</code> on Python 2). Specifically, this affects files on a different device to the user\u2019s home directory, where the root of the device does not have a <code>.Trash</code> directory, and we don\u2019t have permission to create a <code>.Trash-$UID</code> directory.</p>\n\n<p>For any other problem, <code>OSError</code> is raised.</p>",
     "tags": "utility",
     "versions": {
-      "1.8.0": {
+      "1.8.3": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "6a84ab3b7a0d2f8f078d3e4b5ac703f97b9d3ea75bbc006bd594f935871b17f1"
+            "sha256": "934d8af15906f3857b23c77c0e6553077c8dbab46e20c06ffa66c1055be0240f"
           }
         ]
       }
@@ -2646,11 +2646,11 @@
     "usage_notes": "<p>With pyasn1 you can build Python objects from ASN.1 data structures. For example, the following ASN.1 data structure:</p>\n\n<pre><code>\nRecord ::= SEQUENCE {<br>\n  id        INTEGER,<br>\n  room  [0] INTEGER OPTIONAL,<br>\n  house [1] INTEGER DEFAULT 0<br>\n}<br>\n</code></pre>\n\n<p>Could be expressed in pyasn1 like this:</p>\n\n<pre><code>\nclass Record(Sequence):<br>\n    componentType = NamedTypes(<br>\n        NamedType('id', Integer()),<br>\n        OptionalNamedType(<br>\n            'room', Integer().subtype(<br>\n                implicitTag=Tag(tagClassContext, tagFormatSimple, 0)<br>\n            )<br>\n        ),<br>\n        DefaultedNamedType(<br>\n            'house', Integer(0).subtype(<br>\n                implicitTag=Tag(tagClassContext, tagFormatSimple, 1)<br>\n            )<br>\n        )<br>\n    )<br>\n</code></pre>\n\n<p>Refer to <a href=\"https://github.com/etingof/pyasn1/blob/master/README.md\">github</a> for more documentation.</p>",
     "tags": "security utility",
     "versions": {
-      "0.4.9": {
+      "0.6.1": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "4a19b29bbe3123a676df77cb0edafea7b8b6631bcf7c6e3121209f77f39688bf"
+            "sha256": "1953ff26780d695adfa9e8d7319e5381567b6658f30426f31adfe682fce3ea27"
           }
         ]
       }
@@ -2969,11 +2969,11 @@
     "usage_notes": "<p>Usage information is available on <a href=\"https://github.com/aio-libs/async-lru\">github.com</a>.</p>",
     "tags": "programming_tools",
     "versions": {
-      "2.0.4": {
+      "2.0.5": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "03b9c4c98c517cc797f1ef5ec6da5540a0b409157a5c6c24c43d84f20d764eae"
+            "sha256": "4a72af64171ce6ace6c101253a88f37969a56801267e4caf9251696bb9ff10a2"
           }
         ]
       }
@@ -3011,19 +3011,19 @@
     "usage_notes": "<p>Pyrsistent implements a number of different collection types and key features. Documentation should be referenced at <a href=\"https://pyrsistent.readthedocs.io/en/latest/intro.html\">readthedocs.io</a>.</p>",
     "tags": "programming_tools",
     "versions": {
-      "0.19.3.post0": {
+      "0.20.0": {
         "dist": [
           {
             "py_version": "cp311",
-            "sha256": "ace53573214e6240daad807be3b583cbc97d50d0bf1a53b4afe3b6ddd5b3defb"
+            "sha256": "b1f2cea6a88a03b2665fed995fb3a6e3aa6ab9cdf39607c022e013a9a6f1d08b"
           },
           {
             "py_version": "cp312",
-            "sha256": "22f790e68a7e48441b70edf70f6e2c28fc1001f38c84ff4c6e5c73ee3fb4e359"
+            "sha256": "cdd7fcb2bd45748be2d9e022866e65fa9243af476074dde72edf55b9d94d68d9"
           },
           {
             "py_version": "cp313",
-            "sha256": "fc6705747066a9be78a1f7338b422432d33e30b4395ec1f9e512ad7fceb913be"
+            "sha256": "5cf0a684747a9c23f4bc5f3de31280c65949729dc519900f782b6caec5d4c51f"
           }
         ]
       }
@@ -3090,11 +3090,11 @@
     "usage_notes": "<p>Usage information is available on <a href=\"https://flask-cors.readthedocs.io/en/latest/\">readthedocs.io</a>.</p>",
     "tags": "web",
     "versions": {
-      "4.0.0": {
+      "6.0.1": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "b8bf3f354884b3a8df35d3a44cc61d4e16ff7499b76427e3046634a5318aee8c"
+            "sha256": "109c12a48519bc6d0d85e2fca434287798a4bfa38d59507c214eec1baa93da66"
           }
         ]
       }
@@ -3211,11 +3211,11 @@
     "usage_notes": "<p>More information is available on <a href=\"https://github.com/python-hyper/h11\">github.com</a>.</p>",
     "tags": "web",
     "versions": {
-      "0.14.0": {
+      "0.16.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "cd51351488b66567ca5f2855aaf594c96f8d326656a616d2d44052bf4fd86e37"
+            "sha256": "18841c9047540b3e1b3ab742bae2288b1174240cc2f725eab27db2f19b5bca55"
           }
         ]
       }
@@ -3832,11 +3832,11 @@
     "usage_notes": "<p>Please refer to <a href=\"https://nbconvert.readthedocs.io/en/latest/nbconvert_library.html\">readthedocs.io</a> for instructions on how to use this image.</p>",
     "tags": "web utility",
     "versions": {
-      "7.8.0": {
+      "7.16.6": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "6ea90f6064d7be1ac50abb2480b8ff16d1044a9d4774b983106da822d6dae143"
+            "sha256": "db54be1c83e6a6038ebd404787295824b75a75248e34f941d90634ac7908fa8a"
           }
         ]
       }
@@ -4599,11 +4599,11 @@
     "usage_notes": "<p>Documentation for this package is available on <a href=\"https://python-tblib.readthedocs.io/en/latest/readme.html\">readthedocs.io</a>.</p>",
     "tags": "programming_tools",
     "versions": {
-      "1.7.0": {
+      "3.1.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "f3cd22a63042625ea011d5dda3828e561eacfc343e8d84abef50b85f4170a1d9"
+            "sha256": "f528deb4bb6cd132788eb1a6ae768f8560d1806de2bcbe80f87919594acec9f3"
           }
         ]
       }
@@ -4704,11 +4704,11 @@
     "usage_notes": "<p>Usage information is available on <a href=\"https://pypi.org/project/exceptiongroup/\">pypi.org</a>.</p>",
     "tags": "programming_tools",
     "versions": {
-      "1.2.1": {
+      "1.3.0": {
         "dist": [
           {
             "py_version": "py3",
-            "sha256": "e80f0bbcfc6cdbadabbc3ccb4e8435a6b7251289b075e31b45ca3a22fce64324"
+            "sha256": "8c07828d231d81b2698447ebfcbff1511c256981dd5f34b10bccc9bdbe2da146"
           }
         ]
       }
@@ -4947,23 +4947,19 @@
     "usage_notes": "<p>Please refer to <a href=\"https://pandas.pydata.org/pandas-docs/stable/\">pandas.pydata.org</a> for full package documentation.</p>",
     "tags": "programming_tools math machine_learning",
     "versions": {
-      "1.5.1.post2": {
+      "2.3.0": {
         "dist": [
           {
             "py_version": "cp311",
-            "sha256": "fc6be7f9147fbdf6c7a5707b8f22c8399e89567a4b423177b488635f848da44f"
-          }
-        ]
-      },
-      "1.5.1.post3": {
-        "dist": [
-          {
-            "py_version": "cp312",
-            "sha256": "6830019e5d42f074636b63a9ef672275d853279f2bf82794b5660e14c65d32e6"
+            "sha256": "95eee0e45e5b87987d9b2ccd247270d776ccc1760861623078b4699dd9600527"
           },
           {
-            "py_version": "cp311",
-            "sha256": "4eff346445d975fb3a434eb82f5b9de8e03218588b444a27656db964c648e6f7"
+            "py_version": "cp312",
+            "sha256": "825b9664e8c621e3fb1e8413665767512bd3cfa69b8c4d1ae48ec7311a0e707f"
+          },
+          {
+            "py_version": "cp313",
+            "sha256": "ca9d9a0660ae0bf0f8eb63b8b67390e5e2f398e76b9670d35c2009c63a8a2fa8"
           }
         ]
       }


### PR DESCRIPTION
The product page’s Terms of Use section currently points to an outdated license link.
This change updates it to reference the latest license URL.